### PR TITLE
Fix net driver response loss on createEndpoint

### DIFF
--- a/network.go
+++ b/network.go
@@ -1151,6 +1151,11 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	if err = ep.assignAddress(ipam, true, n.enableIPv6 && !n.postIPv6); err != nil {
 		return nil, err
 	}
+	
+	if err = n.addEndpoint(ep); err != nil {
+		return nil, err
+	}
+	
 	defer func() {
 		if err != nil {
 			ep.releaseAddress()
@@ -1169,9 +1174,6 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 		}
 	}()
 
-	if err = n.addEndpoint(ep); err != nil {
-		return nil, err
-	}
 	defer func() {
 		if err != nil {
 			if e := ep.deleteEndpoint(false); e != nil {


### PR DESCRIPTION
Fix related to bug: https://github.com/docker/for-linux/issues/348
We should perform updateToStore(ep) after n.addEndpoint or do update twice, otherwise response from network plugin will not be written to KV storage. This results in container creation with broken network config.